### PR TITLE
dial: retry transient RST on connect

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -601,6 +601,7 @@ func (b *Benchmarker) buildResult(elapsed time.Duration) *Result {
 		RequestsPerSec: rps,
 		ThroughputBPS:  throughput,
 		Latency:        b.latencies.Percentiles(),
+		DialRetries:    snapshotDialRetries(),
 	}
 
 	switch c := b.raw.(type) {

--- a/dial.go
+++ b/dial.go
@@ -1,0 +1,146 @@
+package loadgen
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// dialRetriesCounter is incremented once per retried dial. Call sites
+// (h1client, h2client, h2c_upgrade) drain it into Result.DialRetries at
+// the end of a run. The counter is process-global because dial helpers
+// are called from many goroutines; the caller snapshots via Swap after
+// the run completes.
+var dialRetriesCounter atomic.Uint64
+
+// maxDialAttempts is the total number of TCP SYN attempts per dial,
+// including the first. Only transient SYN-RST responses trigger a
+// retry; every other error fails fast.
+//
+// 3 matches the pragma most TCP stacks apply to their own SYN
+// retransmit ladder before giving up on a connection state race, and
+// covers the observed celeris-side rebind / adaptive-engine switch
+// windows (<5 ms) without slowing the legitimate-failure path more
+// than ~35 ms (10 + 25 ms backoff).
+const maxDialAttempts = 3
+
+// dialBackoffs controls the sleep between retry attempts. Index i is
+// the sleep *before* attempt (i+1) — so [0] is the gap between
+// attempt 1 (which failed) and attempt 2. Length must equal
+// maxDialAttempts-1.
+var dialBackoffs = [...]time.Duration{
+	10 * time.Millisecond,
+	25 * time.Millisecond,
+}
+
+// isTransientDialRST reports whether err came from a SYN getting an
+// RST back during connect. That happens when the peer briefly has no
+// listener on the port (SO_REUSEPORT listener replacement, adaptive
+// engine active-engine switch, conntrack collision) and is entitled
+// to a retry; every other dial error (ETIMEDOUT, EHOSTUNREACH, EMFILE,
+// …) should fail fast.
+func isTransientDialRST(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	// Fall back to string match — net.OpError sometimes wraps the
+	// errno in a way that Is() does not unwrap on every platform.
+	s := err.Error()
+	return containsAny(s,
+		"connection reset by peer",
+		"connection reset",
+		"reset by peer",
+	)
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if indexOf(s, sub) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOf(s, sub string) int {
+	n, m := len(s), len(sub)
+	if m == 0 {
+		return 0
+	}
+	if m > n {
+		return -1
+	}
+	for i := 0; i <= n-m; i++ {
+		if s[i:i+m] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// dialTimeoutFunc is the primitive dialTCPRetry uses under the hood;
+// production paths call net.DialTimeout. The variable is test-only —
+// unit tests swap it out to inject transient-RST errors portably
+// (ECONNRESET vs ECONNREFUSED semantics differ between Linux and
+// Darwin, so a kernel-triggered reproducer would not be portable).
+var dialTimeoutFunc = net.DialTimeout
+
+// dialTCPRetry opens a plain TCP connection to addr with a bounded
+// retry window when the first SYN lands on a momentarily closed
+// listener (RST). Non-RST errors fail on the first attempt.
+func dialTCPRetry(addr string, timeout time.Duration) (net.Conn, error) {
+	var (
+		conn net.Conn
+		err  error
+	)
+	for attempt := 0; attempt < maxDialAttempts; attempt++ {
+		conn, err = dialTimeoutFunc("tcp", addr, timeout)
+		if err == nil {
+			return conn, nil
+		}
+		if !isTransientDialRST(err) {
+			return nil, err
+		}
+		if attempt < maxDialAttempts-1 {
+			dialRetriesCounter.Add(1)
+			time.Sleep(dialBackoffs[attempt])
+		}
+	}
+	return nil, err
+}
+
+// dialTLSRetry dials TLS to addr with RST-retry semantics matching
+// dialTCPRetry.
+func dialTLSRetry(addr string, timeout time.Duration, cfg *tls.Config) (*tls.Conn, error) {
+	var (
+		conn *tls.Conn
+		err  error
+	)
+	for attempt := 0; attempt < maxDialAttempts; attempt++ {
+		conn, err = tls.DialWithDialer(&net.Dialer{Timeout: timeout}, "tcp", addr, cfg)
+		if err == nil {
+			return conn, nil
+		}
+		if !isTransientDialRST(err) {
+			return nil, err
+		}
+		if attempt < maxDialAttempts-1 {
+			dialRetriesCounter.Add(1)
+			time.Sleep(dialBackoffs[attempt])
+		}
+	}
+	return nil, err
+}
+
+// snapshotDialRetries returns the current dial-retry count and resets
+// the global counter. Called once per Benchmarker.Run so the value
+// reported on a Result covers only that run.
+func snapshotDialRetries() uint64 {
+	return dialRetriesCounter.Swap(0)
+}

--- a/dial_test.go
+++ b/dial_test.go
@@ -1,0 +1,99 @@
+package loadgen
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestIsTransientDialRST(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{syscall.ECONNRESET, true},
+		{&net.OpError{Op: "dial", Err: syscall.ECONNRESET}, true},
+		{errors.New("connection reset by peer"), true},
+		{errors.New("dial tcp 127.0.0.1:1234: connect: connection reset by peer"), true},
+		{errors.New("dial tcp 127.0.0.1:1234: connect: reset by peer"), true},
+		{errors.New("i/o timeout"), false},
+		{syscall.ETIMEDOUT, false},
+		{errors.New("no route to host"), false},
+	}
+	for _, tt := range tests {
+		if got := isTransientDialRST(tt.err); got != tt.want {
+			t.Errorf("isTransientDialRST(%v) = %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
+// TestDialTCPRetryRecoversFromRST wires a test-only dial primitive
+// that returns a transient-RST error for the first N attempts then
+// succeeds. Lets the retry loop be validated portably instead of
+// relying on a kernel no-listener-on-port race (ECONNREFUSED vs
+// ECONNRESET is not portable across Linux and Darwin).
+func TestDialTCPRetryRecoversFromRST(t *testing.T) {
+	before := dialRetriesCounter.Swap(0)
+	defer dialRetriesCounter.Add(before)
+
+	var attempts atomic.Int32
+	realDialTimeout := dialTimeoutFunc
+	defer func() { dialTimeoutFunc = realDialTimeout }()
+	dialTimeoutFunc = func(network, _ string, _ time.Duration) (net.Conn, error) {
+		n := attempts.Add(1)
+		if n == 1 {
+			return nil, &net.OpError{Op: "dial", Net: network, Err: syscall.ECONNRESET}
+		}
+		return &net.TCPConn{}, nil
+	}
+
+	conn, err := dialTCPRetry("127.0.0.1:65535", 500*time.Millisecond)
+	if err != nil {
+		t.Fatalf("dialTCPRetry: %v", err)
+	}
+	_ = conn.Close()
+
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2 (1 RST + 1 success)", got)
+	}
+	if n := dialRetriesCounter.Load(); n != 1 {
+		t.Fatalf("expected exactly 1 dial retry, got %d", n)
+	}
+}
+
+// TestDialTCPRetryFailsFastOnNonTransient verifies that
+// dial errors that are NOT connection-reset (e.g. EHOSTUNREACH,
+// EADDRNOTAVAIL) are returned immediately without consuming the retry
+// budget.
+func TestDialTCPRetryFailsFastOnNonTransient(t *testing.T) {
+	before := dialRetriesCounter.Swap(0)
+	defer dialRetriesCounter.Add(before)
+
+	// Dial a port we haven't bound. On Linux this gives connect:
+	// connection refused (ECONNREFUSED), which is NOT a transient RST
+	// for our purposes — should fail on first attempt.
+	start := time.Now()
+	_, err := dialTCPRetry("127.0.0.1:1", 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected dial to fail against unbound port")
+	}
+	if strings.Contains(err.Error(), "reset by peer") {
+		t.Fatalf("unexpected transient RST classification: %v", err)
+	}
+	// Budget = single DialTimeout ≤ 200ms. If we retried, elapsed
+	// would be ≥ 210ms (timeout + backoff). Give a generous 300ms
+	// ceiling for CI noise.
+	if elapsed > 300*time.Millisecond {
+		t.Fatalf("dial took %v — should have failed fast, not retried", elapsed)
+	}
+	if n := dialRetriesCounter.Load(); n != 0 {
+		t.Fatalf("expected 0 retries on non-transient error, got %d", n)
+	}
+}

--- a/h1client.go
+++ b/h1client.go
@@ -170,7 +170,7 @@ func buildH1Request(method, path, host, port string, headers map[string]string, 
 
 func dialH1(addr, scheme string, dialTimeout time.Duration, readBufSize, writeBufSize int, tlsCfg *tls.Config) (net.Conn, error) {
 	if scheme == "https" {
-		conn, err := tls.DialWithDialer(&net.Dialer{Timeout: dialTimeout}, "tcp", addr, tlsCfg)
+		conn, err := dialTLSRetry(addr, dialTimeout, tlsCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -181,7 +181,7 @@ func dialH1(addr, scheme string, dialTimeout time.Duration, readBufSize, writeBu
 		}
 		return conn, nil
 	}
-	conn, err := net.DialTimeout("tcp", addr, dialTimeout)
+	conn, err := dialTCPRetry(addr, dialTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/h2c_upgrade.go
+++ b/h2c_upgrade.go
@@ -143,7 +143,7 @@ func dialH2CUpgrade(addr, scheme, path, host, port string, maxStreams int, dialT
 		return nil, fmt.Errorf("h2c upgrade: not supported over TLS (use -h2 with ALPN instead)")
 	}
 
-	conn, err := net.DialTimeout("tcp", addr, dialTimeout)
+	conn, err := dialTCPRetry(addr, dialTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("h2c upgrade: dial: %w", err)
 	}

--- a/h2client.go
+++ b/h2client.go
@@ -327,17 +327,18 @@ func dialH2(addr, scheme string, maxStreams int, dialTimeout time.Duration, read
 	var conn net.Conn
 	var err error
 	if scheme == "https" {
-		conn, err = tls.DialWithDialer(&net.Dialer{Timeout: dialTimeout}, "tcp", addr, tlsCfg)
-		if err != nil {
-			return nil, err
+		tlsConn, tlsErr := dialTLSRetry(addr, dialTimeout, tlsCfg)
+		if tlsErr != nil {
+			return nil, tlsErr
 		}
-		if tcpConn, ok := conn.(*tls.Conn).NetConn().(*net.TCPConn); ok {
+		conn = tlsConn
+		if tcpConn, ok := tlsConn.NetConn().(*net.TCPConn); ok {
 			_ = tcpConn.SetNoDelay(true)
 			_ = tcpConn.SetReadBuffer(readBufSize)
 			_ = tcpConn.SetWriteBuffer(writeBufSize)
 		}
 	} else {
-		conn, err = net.DialTimeout("tcp", addr, dialTimeout)
+		conn, err = dialTCPRetry(addr, dialTimeout)
 		if err != nil {
 			return nil, err
 		}

--- a/results.go
+++ b/results.go
@@ -32,6 +32,15 @@ type Result struct {
 	// Mix, when non-nil, reports per-protocol request / error / conn counts
 	// for a run using -mix. Omitted for single-protocol runs.
 	Mix *MixStats `json:"mix,omitempty"`
+
+	// DialRetries counts how many TCP SYN retries happened during the
+	// run because the first SYN got an RST back (SO_REUSEPORT listener
+	// replacement, adaptive engine active-engine switch, conntrack
+	// collision, …). Zero in the normal case; a nonzero value is a
+	// release-gate signal that the peer has a brief "no listener on
+	// port" window and the run survived it only because loadgen
+	// retried — the peer may still want to investigate.
+	DialRetries uint64 `json:"dial_retries,omitempty"`
 }
 
 // UpgradeStats summarises the outcome of h2c-upgrade handshakes across all


### PR DESCRIPTION
## Summary

- Retry TCP SYN up to 3 times (10ms, 25ms backoff) when the first attempt gets `connection reset by peer`.
- Other dial errors (EHOSTUNREACH, ETIMEDOUT, ECONNREFUSED, …) fail fast — budget only consumed on transient RST.
- Expose `Result.DialRetries` so release-gate analysis can flag a run that survived only via retry.

Fixes #32.

## Motivation

During the celeris v1.5.0 perfmatrix run on msr1, ~0.75 % of cells failed with `loadgen: dial: h1client: dial conn[0]: connect: connection reset by peer`. The peer's sysctls rule out accept-queue overflow (`somaxconn=65535`, `tcp_abort_on_overflow=0`), so the RSTs are transient state races — `SO_REUSEPORT` listener replacement, adaptive engine active-engine switch during the first load burst, or conntrack collisions. Retrying once is the right client-side response.

## Test plan

- [x] Unit: `TestIsTransientDialRST` — classifier covers `syscall.ECONNRESET`, `*net.OpError` wrapping, and the raw string form reported by `net.DialTimeout`.
- [x] Unit: `TestDialTCPRetryRecoversFromRST` — inject a transient RST on the first attempt via a swappable `dialTimeoutFunc`, assert the dial succeeds on attempt 2 and `DialRetries == 1`. Portable across Linux + Darwin.
- [x] Unit: `TestDialTCPRetryFailsFastOnNonTransient` — dial an unbound port (ECONNREFUSED on both OSes), assert elapsed ≤ 300 ms and `DialRetries == 0`.
- [x] `go test -race ./...` clean (existing 76 s suite unchanged).
- [x] `golangci-lint run` clean.