### PR TITLE
release: ship cmd/loadgen binary tarballs + cluster-bench integration contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write   # upload-release-asset writes back to the release
 
 jobs:
   publish:
@@ -27,3 +27,50 @@ jobs:
           curl -s "https://proxy.golang.org/github.com/goceleris/loadgen/@v/${TAG}.info" || true
           curl -s "https://sum.golang.org/lookup/github.com/goceleris/loadgen@${TAG}" || true
           echo "Published github.com/goceleris/loadgen@${TAG}"
+
+  binaries:
+    # Cross-compiled binary artifacts for `cmd/loadgen` so cluster-bench
+    # orchestrators can fetch them without re-cloning + rebuilding.
+    name: Build cmd/loadgen binaries (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          mkdir -p dist
+          go build -trimpath -ldflags="-s -w" \
+            -o "dist/loadgen-${GOOS}-${GOARCH}" \
+            ./cmd/loadgen
+          ls -la dist/
+      - name: Package
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          cd dist
+          tar czf "loadgen_${GOOS}_${GOARCH}.tar.gz" "loadgen-${GOOS}-${GOARCH}"
+          sha256sum "loadgen_${GOOS}_${GOARCH}.tar.gz" > "loadgen_${GOOS}_${GOARCH}.tar.gz.sha256"
+      - name: Attach to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/loadgen_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
+            dist/loadgen_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz.sha256

--- a/README.md
+++ b/README.md
@@ -208,6 +208,60 @@ The `mix` block in the JSON result reports per-protocol connection counts, reque
 
 Output is JSON with RPS, latency percentiles (p50-p99.99), errors, throughput, and timeseries data.
 
+## Cluster-bench integration contract
+
+`cmd/loadgen` is designed to be invoked remotely (over SSH or by an
+orchestrator like Ansible) on a dedicated load-generation host. The
+contract is:
+
+| Aspect            | Behavior                                                                                         |
+| ----------------- | ------------------------------------------------------------------------------------------------ |
+| **stdout**        | A single pretty-printed JSON `Result` object — no progress noise, no log lines.                  |
+| **stderr**        | Human-readable progress (`<elapsed>  <reqs>  <rps>`), final mix/upgrade summaries, error traces. |
+| **exit 0**        | Benchmark ran to completion (errors during the run are reported in JSON, not via exit code).     |
+| **exit non-zero** | Configuration error (`-url` missing, mutually-exclusive flags, body-file unreadable, etc.).      |
+| **SIGINT / SIGTERM** | Cancels the run *gracefully* — partial Result still printed to stdout, exit 0.                |
+
+### JSON output schema
+
+The shape comes from `loadgen.Result` in `results.go`. Stable fields used by orchestrators:
+
+| Field                         | Type     | Meaning                                                                |
+| ----------------------------- | -------- | ---------------------------------------------------------------------- |
+| `Requests`                    | int64    | Total successful requests during the measurement window.               |
+| `Errors`                      | int64    | Total errors during the measurement window.                            |
+| `Bytes`                       | int64    | Total response body bytes received.                                    |
+| `RequestsPerSec`              | float64  | `Requests / Duration.Seconds()`.                                       |
+| `BytesPerSec`                 | float64  | `Bytes / Duration.Seconds()`.                                          |
+| `Duration`                    | duration | Wall-clock measurement duration (post-warmup).                         |
+| `Latency.{P50,P75,P90,P99,P99_9,P99_99}` | duration | Latency percentiles in nanoseconds.                       |
+| `Mix` (optional)              | object   | Present when `-mix` was used. See "Mix-mode benchmarks" above.         |
+| `Upgrade` (optional)          | object   | Present when `-h2c-upgrade` was used. Records connection upgrade tally.|
+
+### Pre-built binary releases
+
+GitHub Releases ship platform tarballs that orchestrators can fetch directly:
+
+```bash
+TAG=v1.1.0
+OS=linux
+ARCH=amd64
+curl -fsSL "https://github.com/goceleris/loadgen/releases/download/${TAG}/loadgen_${OS}_${ARCH}.tar.gz" \
+  | tar xz -C /tmp/
+chmod +x /tmp/loadgen-${OS}-${ARCH}
+/tmp/loadgen-${OS}-${ARCH} -url http://target:8080/ -duration 10s
+```
+
+A matching `.sha256` file accompanies each archive.
+
+### Reference orchestrator
+
+The celeris cluster bench (see `goceleris/celeris` → `mage clusterBench` +
+`ansible/cluster-bench.yml`) uses this contract. Cross-compiles loadgen
+on the dev machine (or fetches a release tarball), pushes to the
+loadgen host, executes, parses stdout JSON, fetches stderr+stdout to
+the dev box.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

- **Binary releases for `cmd/loadgen`**: the `release.yml` workflow now cross-compiles the CLI for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64` and attaches `loadgen_<os>_<arch>.tar.gz` + matching `.sha256` to every published GitHub release. The existing pkg.go.dev publish step is unchanged.
- **Cluster-bench integration contract** in the README: pins down the CLI's stdout/stderr split, exit codes, signal handling, and JSON result schema fields.

## Why

The celeris cluster bench (in `goceleris/celeris` PR for the v1.4.1 milestone — see [`mage clusterBench`](https://github.com/goceleris/celeris/blob/feat/v1.4.1-middleware-drivers/mage_cluster.go) + [`ansible/cluster-bench.yml`](https://github.com/goceleris/celeris/blob/feat/v1.4.1-middleware-drivers/ansible/cluster-bench.yml)) needs a stable, prebuilt `cmd/loadgen` it can drop onto a remote load-generation host without cloning + rebuilding this repo on each run.

Without binary releases, every cluster-bench invocation has to either (a) clone+rebuild loadgen on the orchestrating machine for both target archs, or (b) `go install ...@latest` into a temp `GOBIN` per run. Both work but waste a few seconds and require Go on every consumer.

## What changed

### `.github/workflows/release.yml`
- New `binaries` job runs after the existing `publish` job
- Matrix: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`
- Each builds with `-trimpath -ldflags='-s -w'` for reproducibility + smaller artifacts
- Uses `softprops/action-gh-release@v2` to attach to the triggering release
- Permissions bumped from `contents: read` → `contents: write` for the asset upload

### `README.md`
New section _Cluster-bench integration contract_ documents:
- stdout = single JSON Result (no progress noise)
- stderr = human progress + summaries
- exit 0 on completion (run-time errors live in JSON)
- exit non-zero only for config errors
- SIGINT/SIGTERM = graceful cancel, partial Result still printed, exit 0
- JSON schema field reference (Requests, Errors, RPS, Latency.P50…P99_99, Mix, Upgrade)
- Quick `curl | tar xz` recipe for fetching a release tarball

## Test plan

- [ ] Tag a draft release and confirm the four archives + `.sha256` files attach correctly (or run the workflow manually with `act` first if available)
- [ ] Download `loadgen_linux_amd64.tar.gz`, verify `sha256sum -c`, run `./loadgen -url http://localhost:8080/ -duration 1s` — expect a JSON object on stdout, exit 0
- [ ] Verify `kill -INT <pid>` mid-run produces a partial JSON Result on stdout and exit 0
- [ ] Verify `loadgen` (no args) exits non-zero with a usage hint

- Closes #36
