### PR TITLE
release: drop redundant .sha256 sidecar files (v1.3.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,7 @@ jobs:
         run: |
           cd dist
           tar czf "loadgen_${GOOS}_${GOARCH}.tar.gz" "loadgen-${GOOS}-${GOARCH}"
-          sha256sum "loadgen_${GOOS}_${GOARCH}.tar.gz" > "loadgen_${GOOS}_${GOARCH}.tar.gz.sha256"
       - name: Attach to release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            dist/loadgen_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
-            dist/loadgen_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz.sha256
+          files: dist/loadgen_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz

--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ chmod +x /tmp/loadgen-${OS}-${ARCH}
 /tmp/loadgen-${OS}-${ARCH} -url http://target:8080/ -duration 10s
 ```
 
-A matching `.sha256` file accompanies each archive.
+GitHub displays the SHA-256 of each release asset on the release page —
+`gh release download <tag>` and the GitHub UI verify checksums automatically,
+so the workflow doesn't ship a separate `.sha256` sidecar.
 
 ### Reference orchestrator
 


### PR DESCRIPTION
## Summary

- Drop the `sha256sum > loadgen_<os>_<arch>.tar.gz.sha256` step from `.github/workflows/release.yml`.
- Stop attaching the four `*.sha256` sidecar files to GitHub releases.
- Update the README's binary-release section to point users at GitHub's native SHA-256 display (and `gh release download`'s automatic verification) instead of the sidecar.

## Why

[v1.3.0's release page](https://github.com/goceleris/loadgen/releases/tag/v1.3.0) ended up with 10 assets — 4 binary tarballs and 4 `.sha256` files duplicating data that GitHub already shows next to every asset in the UI. The sidecars added noise without adding trust:

- the platform-rendered SHA in GitHub's UI is canonical and tamper-evident the same way the tarball is
- `gh release download` already verifies tarballs against the GitHub-stored SHA without consulting any sidecar
- if the workflow ever regenerates the tarball and skips the sha256sum step, the sidecar would silently lie

## Test plan

- [ ] Cut a v1.3.1 tag from main once this lands; confirm the release page shows 4 tarballs (no `.sha256`s) plus the auto-generated source archives.
- [ ] `gh release download v1.3.1 --repo goceleris/loadgen` succeeds and reports verified SHA-256 against the GitHub-stored hash.
- [ ] The cluster-bench orchestrator (celeris `mage clusterDeploy`) still finds and downloads `loadgen_<os>_<arch>.tar.gz` unchanged — it never consumed the sidecar.

- Closes #38