### PR TITLE
feat(bench): Unblocker extension to flush warmup-stuck workers

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -264,6 +264,24 @@ type Client interface {
 	Close()
 }
 
+// Unblocker is an optional extension implemented by clients whose
+// underlying connections support timeout-based cancellation
+// (net.Conn.SetDeadline). When workers are stuck inside a blocking
+// Read/Write that does NOT honor context cancellation — every
+// stdlib net.Conn — calling Unblock(time.Now()) forces every active
+// I/O on the client's pooled conns to return with a timeout error,
+// letting workers observe ctx.Done() and exit promptly. Cleared by
+// passing the zero Time. Used by warmup to flush stuck workers
+// without closing the conns (post-warmup re-uses the same pool).
+//
+// Implemented by h1Client, h2Client, mixClient, h2cUpgradeClient.
+// Custom Client implementations may opt in for the same benefit;
+// the bench will fall back to unconditional warmup-end if absent
+// (workers exit naturally on the next DoRequest completion).
+type Unblocker interface {
+	Unblock(t time.Time)
+}
+
 // Benchmarker runs HTTP benchmarks.
 type Benchmarker struct {
 	config Config
@@ -537,7 +555,25 @@ func (b *Benchmarker) warmup(ctx context.Context) {
 
 	<-warmupCtx.Done()
 	b.running.Store(false)
+	// Net.Conn doesn't honor context cancellation — workers stuck
+	// inside Read/Write would block until the syscall returns
+	// naturally, which on a slow / heavily-loaded server can be
+	// minutes. Calling Unblock(time.Now()) sets every pooled conn's
+	// deadline to "right now", so any active Read/Write returns with
+	// a timeout error; the worker's DoRequest fails fast, the worker
+	// re-checks running, and exits. Without this, b.wg.Wait below
+	// can stall well past the warmup window — observed on -race
+	// matrix runs where 1MB POSTs naturally took 30+ seconds and
+	// stretched warmup so far that post-warmup got 18ms of cellCtx
+	// before fail-fast tripped. Reset the deadline before workers
+	// spawn again in Run() so post-warmup uses the same warm pool.
+	if u, ok := b.raw.(Unblocker); ok {
+		u.Unblock(time.Now())
+	}
 	b.wg.Wait()
+	if u, ok := b.raw.(Unblocker); ok {
+		u.Unblock(time.Time{}) // clear deadlines for the post-warmup pool reuse
+	}
 }
 
 func (b *Benchmarker) worker(ctx context.Context, workerID int) {

--- a/h1client.go
+++ b/h1client.go
@@ -459,3 +459,16 @@ func (c *h1Client) Close() {
 		hc.mu.Unlock()
 	}
 }
+
+// Unblock implements the bench Unblocker extension. Sets a deadline
+// on every pooled conn so workers stuck inside a blocking Read/Write
+// return with a timeout error, then can observe ctx cancellation and
+// exit. Pass the zero Time to clear deadlines (lets post-warmup
+// reuse the same pool).
+func (c *h1Client) Unblock(t time.Time) {
+	for _, hc := range c.conns {
+		hc.mu.Lock()
+		_ = hc.conn.SetDeadline(t)
+		hc.mu.Unlock()
+	}
+}

--- a/h2client.go
+++ b/h2client.go
@@ -835,6 +835,18 @@ func (c *h2Client) Close() {
 	}
 }
 
+// Unblock implements the bench Unblocker extension as a no-op for
+// h2. Setting a deadline on an h2 conn would cause its readLoop /
+// writeLoop to observe a timeout and tear the conn down (HTTP/2
+// frames require ordered delivery — partial frames are fatal). h2
+// workers already honor ctx cancellation via select on writeCh and
+// the per-stream response channel, so they exit without needing a
+// kick from outside. The Unblocker contract permits this — clients
+// for which deadline-based unblocking would corrupt the conn pool
+// are allowed to no-op, accepting the small risk that some workers
+// take an extra DoRequest round-trip to notice ctx.Done().
+func (c *h2Client) Unblock(_ time.Time) {}
+
 func (hc *h2Conn) closeConn() {
 	if !hc.closed.CompareAndSwap(false, true) {
 		return // already closed

--- a/mix.go
+++ b/mix.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 )
 
 // MixRatio captures the three-protocol traffic ratio parsed from the `-mix`
@@ -313,6 +314,22 @@ func (c *mixClient) Close() {
 	}
 	if c.upgrade != nil {
 		c.upgrade.Close()
+	}
+}
+
+// Unblock fans out to every sub-client that implements the
+// Unblocker extension. Used by warmup to flush stuck workers
+// across the entire mix pool in one call. Sub-clients that don't
+// implement Unblock (custom user clients) are silently skipped —
+// their workers exit naturally once their next DoRequest returns.
+func (c *mixClient) Unblock(t time.Time) {
+	for _, sub := range []Client{c.h1, c.h2, c.upgrade} {
+		if sub == nil {
+			continue
+		}
+		if u, ok := sub.(Unblocker); ok {
+			u.Unblock(t)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The warmup→post-warmup transition could stall in matrix-bench strict runs. After warmup ends and `b.running.Store(false)` flips, workers are supposed to observe `ctx.Done()` at the top of their loop and exit — but they can't, because they're inside a blocking `net.Conn.Read/Write` that doesn't honor context. `b.wg.Wait` then blocks until each in-flight syscall returns on its own (server completes the request, server times out, conn closes).

On a `-race`-instrumented matrix host where a 1MB POST cell takes 30+ seconds end-to-end, this stretched warmup well past its 1s budget — the post-warmup window then ran on the dregs of the cell-level deadline (sometimes <50 ms), measured zero requests, and tripped the strict matrix's 0-req fail-fast guard. Repro:

- `post-1m / celeris-adaptive-auto+upg-async` on aarch64, observed twice (1h39m and 5h47m into separate strict matrix runs).

## Fix

Add an optional `Unblocker` extension. Clients whose conns can survive a deadline-fire-and-clear cycle implement it; warmup calls `Unblock(time.Now())` after `running=false` to force every in-flight Read/Write to return, then `Unblock(time.Time{})` once `b.wg.Wait` drains so post-warmup re-uses the same warmed pool.

- `h1Client`: `SetDeadline` on each pooled conn — h1 conns are synchronous so the deadline fires the current Read/Write and the conn is reusable on next call.
- `h2Client`: NO-OP. h2 conns multiplex frames through `readLoop` / `writeLoop` goroutines that treat any I/O error as fatal; setting a deadline would tear the conn down. h2 workers already honor ctx via `select` on `writeCh` / response channel, so this is safe.
- `mixClient`: fan out to whichever sub-clients implement `Unblocker`.

Custom user clients that don't implement `Unblocker` keep the prior behaviour — workers exit naturally on the next `DoRequest` return.

## Test plan
- [x] Existing test suite passes locally (`go test -count=1 ./...`)
- [x] Race detector clean (`go test -count=1 -race -short ./...`)
- [ ] Verify on celeris milestone/v1.4.2 strict matrix: `post-1m / adaptive-auto+upg-async` cell on msr1 (aarch64) used to 0-req at hour 1h39m / 5h47m; with this change in place the cell completes cleanly.