### PR TITLE
fix(h1): Unblock now closes the conn rather than SetDeadline

### DIFF
--- a/h1client.go
+++ b/h1client.go
@@ -460,15 +460,26 @@ func (c *h1Client) Close() {
 	}
 }
 
-// Unblock implements the bench Unblocker extension. Sets a deadline
-// on every pooled conn so workers stuck inside a blocking Read/Write
-// return with a timeout error, then can observe ctx cancellation and
-// exit. Pass the zero Time to clear deadlines (lets post-warmup
-// reuse the same pool).
+// Unblock implements the bench Unblocker extension. Closes every
+// pooled conn so workers stuck inside a blocking Read/Write return
+// with a closed-conn error, then observe ctx cancellation and
+// exit. Closing (rather than SetDeadline) is intentional: a Read
+// interrupted mid-response leaves partial bytes in the conn's
+// bufio buffer that the next request would mis-parse; closing
+// guarantees a clean conn for the post-warmup worker, which re-
+// establishes the conn lazily via the existing reconnect-on-write
+// path inside DoRequest. Pass the zero Time as a no-op.
 func (c *h1Client) Unblock(t time.Time) {
+	if t.IsZero() {
+		// Clear: post-warmup workers reconnect lazily — nothing to do
+		// here. Kept as a documented no-op so the Unblocker contract
+		// stays symmetric (workers may also call this from the
+		// time.After cleanup path; the second call is harmless).
+		return
+	}
 	for _, hc := range c.conns {
 		hc.mu.Lock()
-		_ = hc.conn.SetDeadline(t)
+		_ = hc.conn.Close()
 		hc.mu.Unlock()
 	}
 }


### PR DESCRIPTION
## Summary

The Unblock implementation shipped in v1.4.0 used \`net.Conn.SetDeadline(time.Now())\` so a warmup-stuck worker would receive a timeout error and exit. The problem: a Read interrupted mid-response leaves partial bytes in h1Conn's bufio reader. The next post-warmup request on the same conn mis-parses those leftovers as the new response — at best records a stale request as fresh, at worst stalls indefinitely waiting for the rest of a response that never arrives.

## Repro

celeris milestone/v1.4.2 strict matrix back-to-back on msr1 (aarch64): \`chain-api-get-json-1c / chi-h1\` cell hit 0-req-0-err with full 5.866s post-warmup duration after 4h17m of clean execution.

## Fix

Switch Unblock to Close: closing every pooled conn forces any active Read/Write to return EOF, the worker exits cleanly, and post-warmup's first request triggers the existing reconnect-on-write retry path in h1Client.DoRequest.

Cost: one fresh dial per warmup→post-warmup boundary (~1ms × 64 conns = ~64ms), invisible against the warmup duration.

\`Unblock(time.Time{})\` becomes a no-op (clear is implicit since the post-warmup conns are fresh after reconnect).

## Test plan
- [x] Existing test suite passes (\`go test -count=1 ./...\`)
- [x] Race detector clean (\`go test -count=1 -race -short ./...\`)
- [ ] Verify on celeris milestone/v1.4.2: 2 back-to-back full strict matrix passes on msr1 with this v1.4.1 in place.