### PR TITLE
revert: roll back Unblocker extension (#42, #43)

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -264,24 +264,6 @@ type Client interface {
 	Close()
 }
 
-// Unblocker is an optional extension implemented by clients whose
-// underlying connections support timeout-based cancellation
-// (net.Conn.SetDeadline). When workers are stuck inside a blocking
-// Read/Write that does NOT honor context cancellation — every
-// stdlib net.Conn — calling Unblock(time.Now()) forces every active
-// I/O on the client's pooled conns to return with a timeout error,
-// letting workers observe ctx.Done() and exit promptly. Cleared by
-// passing the zero Time. Used by warmup to flush stuck workers
-// without closing the conns (post-warmup re-uses the same pool).
-//
-// Implemented by h1Client, h2Client, mixClient, h2cUpgradeClient.
-// Custom Client implementations may opt in for the same benefit;
-// the bench will fall back to unconditional warmup-end if absent
-// (workers exit naturally on the next DoRequest completion).
-type Unblocker interface {
-	Unblock(t time.Time)
-}
-
 // Benchmarker runs HTTP benchmarks.
 type Benchmarker struct {
 	config Config
@@ -555,25 +537,7 @@ func (b *Benchmarker) warmup(ctx context.Context) {
 
 	<-warmupCtx.Done()
 	b.running.Store(false)
-	// Net.Conn doesn't honor context cancellation — workers stuck
-	// inside Read/Write would block until the syscall returns
-	// naturally, which on a slow / heavily-loaded server can be
-	// minutes. Calling Unblock(time.Now()) sets every pooled conn's
-	// deadline to "right now", so any active Read/Write returns with
-	// a timeout error; the worker's DoRequest fails fast, the worker
-	// re-checks running, and exits. Without this, b.wg.Wait below
-	// can stall well past the warmup window — observed on -race
-	// matrix runs where 1MB POSTs naturally took 30+ seconds and
-	// stretched warmup so far that post-warmup got 18ms of cellCtx
-	// before fail-fast tripped. Reset the deadline before workers
-	// spawn again in Run() so post-warmup uses the same warm pool.
-	if u, ok := b.raw.(Unblocker); ok {
-		u.Unblock(time.Now())
-	}
 	b.wg.Wait()
-	if u, ok := b.raw.(Unblocker); ok {
-		u.Unblock(time.Time{}) // clear deadlines for the post-warmup pool reuse
-	}
 }
 
 func (b *Benchmarker) worker(ctx context.Context, workerID int) {

--- a/h1client.go
+++ b/h1client.go
@@ -459,27 +459,3 @@ func (c *h1Client) Close() {
 		hc.mu.Unlock()
 	}
 }
-
-// Unblock implements the bench Unblocker extension. Closes every
-// pooled conn so workers stuck inside a blocking Read/Write return
-// with a closed-conn error, then observe ctx cancellation and
-// exit. Closing (rather than SetDeadline) is intentional: a Read
-// interrupted mid-response leaves partial bytes in the conn's
-// bufio buffer that the next request would mis-parse; closing
-// guarantees a clean conn for the post-warmup worker, which re-
-// establishes the conn lazily via the existing reconnect-on-write
-// path inside DoRequest. Pass the zero Time as a no-op.
-func (c *h1Client) Unblock(t time.Time) {
-	if t.IsZero() {
-		// Clear: post-warmup workers reconnect lazily — nothing to do
-		// here. Kept as a documented no-op so the Unblocker contract
-		// stays symmetric (workers may also call this from the
-		// time.After cleanup path; the second call is harmless).
-		return
-	}
-	for _, hc := range c.conns {
-		hc.mu.Lock()
-		_ = hc.conn.Close()
-		hc.mu.Unlock()
-	}
-}

--- a/h2client.go
+++ b/h2client.go
@@ -835,18 +835,6 @@ func (c *h2Client) Close() {
 	}
 }
 
-// Unblock implements the bench Unblocker extension as a no-op for
-// h2. Setting a deadline on an h2 conn would cause its readLoop /
-// writeLoop to observe a timeout and tear the conn down (HTTP/2
-// frames require ordered delivery — partial frames are fatal). h2
-// workers already honor ctx cancellation via select on writeCh and
-// the per-stream response channel, so they exit without needing a
-// kick from outside. The Unblocker contract permits this — clients
-// for which deadline-based unblocking would corrupt the conn pool
-// are allowed to no-op, accepting the small risk that some workers
-// take an extra DoRequest round-trip to notice ctx.Done().
-func (c *h2Client) Unblock(_ time.Time) {}
-
 func (hc *h2Conn) closeConn() {
 	if !hc.closed.CompareAndSwap(false, true) {
 		return // already closed

--- a/mix.go
+++ b/mix.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"time"
 )
 
 // MixRatio captures the three-protocol traffic ratio parsed from the `-mix`
@@ -314,22 +313,6 @@ func (c *mixClient) Close() {
 	}
 	if c.upgrade != nil {
 		c.upgrade.Close()
-	}
-}
-
-// Unblock fans out to every sub-client that implements the
-// Unblocker extension. Used by warmup to flush stuck workers
-// across the entire mix pool in one call. Sub-clients that don't
-// implement Unblock (custom user clients) are silently skipped —
-// their workers exit naturally once their next DoRequest returns.
-func (c *mixClient) Unblock(t time.Time) {
-	for _, sub := range []Client{c.h1, c.h2, c.upgrade} {
-		if sub == nil {
-			continue
-		}
-		if u, ok := sub.(Unblocker); ok {
-			u.Unblock(t)
-		}
 	}
 }
 


### PR DESCRIPTION
Both #42 and the follow-up #43 introduced subtler problems than they solved. See commit message for the full root-cause analysis. The matrix-bench timing pressure that motivated Unblocker is better absorbed in the consumer's per-cell timeout (celeris milestone/v1.4.2 already does this).

## Test plan
- [x] go test -count=1 -short ./... passes
- [x] go test -count=1 -race -short ./... passes
- [ ] celeris back-to-back strict matrix passes 2 consecutive full sweeps on msr1