### PR TITLE
chore(deps): bump Go to 1.26.3 (stdlib CVE fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
       - name: Run tests
         run: go test -race -count=1 -timeout 120s ./...
 
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
       # The testserver helper imports github.com/goceleris/celeris (pinned in
       # go.mod). Integration tests spawn it as a subprocess per matrix cell,
       # then drive loadgen against the live server via the library API. -race

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
       - name: Verify module
         run: |
           go mod verify
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goceleris/loadgen
 
-go 1.26.0
+go 1.26.3
 
 require (
 	github.com/goceleris/celeris v1.4.1


### PR DESCRIPTION
Bumps go.mod directive 1.26.0 → 1.26.3 and CI go-version 1.26 → 1.26.3 to absorb the stdlib fixes for GO-2026-4971 and GO-2026-4918, both surfaced by govulncheck on the celeris milestone/v1.4.2 PR. Build + short test suite pass under 1.26.3 locally.