### PR TITLE
chore(ci): add actionlint to the Lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9
+      - name: actionlint
+        # Workflow-YAML lint: catches script-injection vectors, unknown
+        # runner labels, malformed shell, action input misuse — the
+        # whole class golangci-lint can't see.
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@latest
+          actionlint -color
 
   test:
     name: Test


### PR DESCRIPTION
Adds actionlint to the existing Lint job so this repo's own GitHub Actions YAML is sanity-checked on every PR — script-injection vectors, unknown runner labels, malformed shell, action input misuse. ~5s overhead, uses the same checkout + setup-go that already runs.