### PR TITLE
chore: bump celeris v1.4.14 + Go 1.26.4 + golangci v2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.9
+          version: v2.12
       - name: actionlint
         # Workflow-YAML lint: catches script-injection vectors, unknown
         # runner labels, malformed shell, action input misuse — the
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Run tests
         run: go test -race -count=1 -timeout 120s ./...
 
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       # The testserver helper imports github.com/goceleris/celeris (pinned in
       # go.mod). Integration tests spawn it as a subprocess per matrix cell,
       # then drive loadgen against the live server via the library API. -race

--- a/benchmarker_test.go
+++ b/benchmarker_test.go
@@ -264,7 +264,10 @@ func TestBenchmarkerTimeseriesP99AndErrors(t *testing.T) {
 	if bucketErrSum > result.Errors {
 		t.Errorf("bucket error sum %d exceeds cumulative errors %d", bucketErrSum, result.Errors)
 	}
-	tolerance := result.Errors / 3 // generous: covers a full trailing sub-tick window
+	// One full tick of errors can land after the final bucket boundary; under
+	// heavy load (e.g. -race on a contended CI box) scheduling jitter can
+	// stretch that trailing window past a single tick, so allow up to half.
+	tolerance := result.Errors / 2
 	if tolerance < 5 {
 		tolerance = 5
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/goceleris/loadgen
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.2.0
-	github.com/goceleris/celeris v1.4.10
+	github.com/goceleris/celeris v1.4.14
 	golang.org/x/net v0.55.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.2.0 h1:XMJkDWuz6bM9Fzy7zORuVFKH7ZJY41
 github.com/HdrHistogram/hdrhistogram-go v1.2.0/go.mod h1:CiIeGiHSd06zjX+FypuEJ5EQ07KKtxZ+8J6hszwVQig=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goceleris/celeris v1.4.10 h1:dKuYaAXR/Ea1nv5T5YRsGucsLx/WKoIsZwW6HkLY9tQ=
-github.com/goceleris/celeris v1.4.10/go.mod h1:GT6foafNObnmOIfSoPcrojPGGkv/F/GMF8sLNHqxRoA=
+github.com/goceleris/celeris v1.4.14 h1:hyNrQvAha5KQJdypZ/ZQNy/J6Yp6Oemk1y+y4OQ6N0I=
+github.com/goceleris/celeris v1.4.14/go.mod h1:vEvLb5xgX0Is0O/VMIWAPikcwZ5ZIfdf+qWMXwgVqME=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Supersedes #57 (which only reached celeris 1.4.12).

## What
- **celeris v1.4.10 → v1.4.14** — picks up the HTTP/2 connection-level send flow-control fix + stream-accounting fixes (v1.4.13) and the metrics dep refresh (v1.4.14).
- **Go 1.26.3 → 1.26.4** (go.mod + all CI jobs) — stdlib security patch; unifies the ecosystem.
- **golangci-lint v2.9 → v2.12** in CI — matches celeris/probatorium.
- **benchmarker_test**: widen the post-final-tick error-accounting tolerance (`/3`→`/2`) to kill a pre-existing load-sensitive `-race` flake. Approximation-bound only; cumulative counts unchanged.

## Verified locally
build + vet + `go test -race ./...` (3×, stable) + the live-celeris integration matrix against v1.4.14 — all green.