### PR TITLE
ci(release): bump release workflow Go to 1.26.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Verify module
         run: |
           go mod verify
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}


### PR DESCRIPTION
The release workflow pinned Go 1.26.3 while go.mod now requires 1.26.4 (`GOTOOLCHAIN=local`), so v1.4.6's `Verify module` + binary-build jobs failed. The module published fine via the tag (proxy has v1.4.6, and probatorium cross-builds loadgen from source anyway), so nothing downstream is affected — this just makes future release runs green and finishes the Go-1.26.4 unification.