### PR TITLE
chore(release): bump celeris v1.5.4 → v1.5.5 (loadgen v1.4.11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.2.0
-	github.com/goceleris/celeris v1.5.4
+	github.com/goceleris/celeris v1.5.5
 	golang.org/x/net v0.56.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.2.0 h1:XMJkDWuz6bM9Fzy7zORuVFKH7ZJY41
 github.com/HdrHistogram/hdrhistogram-go v1.2.0/go.mod h1:CiIeGiHSd06zjX+FypuEJ5EQ07KKtxZ+8J6hszwVQig=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goceleris/celeris v1.5.4 h1:mPHo5CsZx+J8has9yXK3vvmmgEV6eOiiVYC8DHDk08U=
-github.com/goceleris/celeris v1.5.4/go.mod h1:usrqjcfMxiNA4lFoE/YbEzX10+UFhoJ4JQVkAS7noSc=
+github.com/goceleris/celeris v1.5.5 h1:wgJ3gVgYINQBQwgLteu3w8msEDPEddt4Tf4WUTs0qOM=
+github.com/goceleris/celeris v1.5.5/go.mod h1:usrqjcfMxiNA4lFoE/YbEzX10+UFhoJ4JQVkAS7noSc=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/version.go
+++ b/version.go
@@ -12,7 +12,7 @@ const modulePath = "github.com/goceleris/loadgen"
 // fallbackVersion is reported when build info carries no usable module
 // version for loadgen ((devel) builds, tests, directory replaces). Keep in
 // sync with the release tag.
-const fallbackVersion = "1.4.10"
+const fallbackVersion = "1.4.11"
 
 // Version is the loadgen release version, stamped into Result.LoadgenVersion
 // so downstream consumers (probatorium, perfmatrix) can record which loadgen


### PR DESCRIPTION
Bumps the celeris dependency to the just-released **v1.5.5** so loadgen v1.4.11 transitively carries it for probatorium to pin.

celeris v1.5.5 = io_uring slowloris-timer cancel + postgres ExecContext prepared-statement cache (validated +21% pg-write) + keyauth ErrUnauthorized chaining (#391) + overload godoc (#392).

Verified locally: `go build`/`go vet`/`go test -race ./...` green, and the H2C integration matrix (`TestIntegrationH2CMatrix`, live celeris v1.5.5 subprocess, all proto×upgrade combos) passes. No loadgen source changes — dependency bump only.